### PR TITLE
Implemented reusing groupme tabs

### DIFF
--- a/notifications.js
+++ b/notifications.js
@@ -13,9 +13,24 @@ Notifications = (function(){
   var click = function(id){
     var notification = findNotificationById(id);
     if (notification){
-      chrome.tabs.create({
-        url: "https://app.groupme.com/chats/" + notification.groupId
-      }, function(tab) {});
+      var newURL = "https://app.groupme.com/chats/" + notification.groupId;
+      chrome.tabs.query({"url" : "https://app.groupme.com/*"}, function(tabs){
+        if (tabs.length > 0){
+          var matchedTab = tabs[0];
+          chrome.windows.update(matchedTab.windowId, { 
+            "focused" : true
+          });
+		  chrome.tabs.update(matchedTab.id, {
+            "active" : true, "url" : newURL
+			// changing url reloads the page (which may not be the best solution)
+          });
+        }
+        else {
+          chrome.tabs.create({
+            url : newURL
+          }, function(tab){});
+        } 
+      });
     }
   };
   chrome.notifications.onClicked.addListener(click);


### PR DESCRIPTION
Note: currently changes the url of the tab to be reused.
Not always the best idea because it reloads the page to show the
appropriate group (even if that group is already showing on the page).

I'm thinking of just leaving the url as is and finding some way to get
the appropriate chat to display (maybe there is something in the API?)
